### PR TITLE
Cache registration status, so we risk fewer API calls to REDCap.

### DIFF
--- a/husky_musher/utils/cache.py
+++ b/husky_musher/utils/cache.py
@@ -26,7 +26,7 @@ class Cache:
         return key
 
     @staticmethod
-    def _sanitize_value(value: Any):
+    def _sanitize_value(value: Any, force_json: bool = False):
         """
         If the value is not already of a type supported by redis,
         assume it to be a something json-serializable, and attempt
@@ -41,7 +41,7 @@ class Cache:
         >>> Cache._sanitize_value('123')
         '123'
         """
-        if not isinstance(value, (bytes, str, int, float)):
+        if force_json or not isinstance(value, (bytes, str, int, float)):
             return json.dumps(value)
         return value
 
@@ -73,7 +73,7 @@ class Cache:
             return cast_as(value)
         return value
 
-    def set(self, key: str, value: Any, expire_seconds: Optional[int] = None):
+    def set(self, key: str, value: Any, expire_seconds: Optional[int] = None, save_json: bool = False):
         """
         Adds an entry to the cache. If the entry is a serializable object,
         it will be converted to json. Otherwise, its underlying type will
@@ -93,7 +93,7 @@ class Cache:
         TypeError: Object of type set is not JSON serializable
         """
         key = self.sanitize_key(key)
-        value = self._sanitize_value(value)
+        value = self._sanitize_value(value, force_json=save_json)
         self.redis.set(key, value, ex=expire_seconds)
 
     def delete(self, key: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "husky-musher"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
- Rename `generate_survey_link` to `generate_enrollment_survey_link`
- Only generate an enrollment survey link if the user's registration is incomplete.
- Cache registration status to avoid unnecessary API calls. If the cache is cleared, we will make those unnecessary calls again, but only until the next time the cache is cleared.